### PR TITLE
Added catch to skip non-video nfo files

### DIFF
--- a/ytdl_nfo/Ytdl_nfo.py
+++ b/ytdl_nfo/Ytdl_nfo.py
@@ -24,7 +24,13 @@ class Ytdl_nfo:
         self.nfo = get_config(self.extractor)
 
     def process(self):
+        if self.data['_type'] != "video":
+            print(f'{self.filename} is not a video metadata file, Skipping')
+            return False
+
         self.nfo.generate(self.data)
+        self.write_nfo()
+        return True
 
     def write_nfo(self):
         self.nfo.write_nfo(f'{self.filename}.nfo')

--- a/ytdl_nfo/__init__.py
+++ b/ytdl_nfo/__init__.py
@@ -25,7 +25,6 @@ def main():
         print(f'Processing {args.input} with {extractor_str} extractor')
         file = Ytdl_nfo(args.input, args.extractor)
         file.process()
-        file.write_nfo()
     else:
         for root, dirs, files in os.walk(args.input):
             for file_name in files:
@@ -42,7 +41,6 @@ def main():
                             f'Processing {args.input} with {extractor_str} extractor')
                         file = Ytdl_nfo(file_path, args.extractor)
                         file.process()
-                        file.write_nfo()
 
 
 def get_config_path():


### PR DESCRIPTION
Addresses #11 

Catch when `_type` is not `video` and do not generate or process `.nfo` to avoid configuration crashes.

