### PR TITLE
Fixed regex multi-search bug and nfo name write bug

### DIFF
--- a/ytdl_nfo/Ytdl_nfo.py
+++ b/ytdl_nfo/Ytdl_nfo.py
@@ -20,13 +20,14 @@ class Ytdl_nfo:
             self.filename = file_path[:-10]
         else:
             self.filename = os.path.splitext(self.data['_filename'])[0]
+
         self.nfo = get_config(self.extractor)
 
     def process(self):
         self.nfo.generate(self.data)
 
     def write_nfo(self):
-        self.nfo.write_nfo(os.path.join(self.dir, f'{self.filename}.nfo'))
+        self.nfo.write_nfo(f'{self.filename}.nfo')
 
     def print_data(self):
         print(json.dumps(self.data, indent=4, sort_keys=True))

--- a/ytdl_nfo/__init__.py
+++ b/ytdl_nfo/__init__.py
@@ -34,12 +34,12 @@ def main():
 
                     path_no_ext = os.path.splitext(file_path)[0]
                     info_re = r".info$"
-                    if re.search(info_re):
+                    if re.search(info_re, file_name):
                         path_no_ext = re.sub(info_re, '', path_no_ext)
 
                     if args.overwrite or not os.path.exists(path_no_ext + ".nfo"):
                         print(
-                            f'Processing {file_path} with extractor {args.extractor}')
+                            f'Processing {args.input} with {extractor_str} extractor')
                         file = Ytdl_nfo(file_path, args.extractor)
                         file.process()
                         file.write_nfo()


### PR DESCRIPTION
Fixed
- Regex multi-search broken due to syntax error
- Write_nfo generating the wrong filename
- Multi-extractor statement not displaying correct string