### PR TITLE
Removed _type check due for youtube-dl compatability

### DIFF
--- a/ytdl_nfo/Ytdl_nfo.py
+++ b/ytdl_nfo/Ytdl_nfo.py
@@ -24,9 +24,6 @@ class Ytdl_nfo:
         self.nfo = get_config(self.extractor)
 
     def process(self):
-        if self.data['_type'] != "video":
-            print(f'{self.filename} is not a video metadata file, Skipping')
-            return False
 
         self.nfo.generate(self.data)
         self.write_nfo()


### PR DESCRIPTION
Solves #20.

### Problem:
youtube-dl does not use insert the `_type` key which yt-dlp uses. The check was previously used to ensure that only video metadata was being processed, however since it breaks youtube-dl compatibility it's best to forgo this check for now to enable working functionality. 

### Solution:
Remove the `_type` key check and assume valid files.