### PR TITLE
feat: add bilibili config to convert bilibili nfo

### DIFF
--- a/ytdl_nfo/configs/bilibili.yaml
+++ b/ytdl_nfo/configs/bilibili.yaml
@@ -1,0 +1,14 @@
+episodedetails:
+  - title: '{title}'
+  - showtitle: '{uploader}'
+  - uniqueid:
+      attr:
+        type: 'bilibili'
+        default: "true"
+      value: '{id}'
+  - plot: '{description}'
+  - premiered:
+      convert: 'date'
+      input_f: '%Y%m%d'
+      output_f: '%Y-%m-%d'
+      value: '{upload_date}'


### PR DESCRIPTION
`ytdl-nfo` is a very awesome project! I using it in my project(https://github.com/CorrectRoadH/Media-Fetch-Pro). 
I need to add a config for bilibili. I try it in my compute and it working fine! I want merge it to upstream and release a new version.