### PR TITLE
Fix issues 25 and 26

### DIFF
--- a/ytdl_nfo/Ytdl_nfo.py
+++ b/ytdl_nfo/Ytdl_nfo.py
@@ -7,30 +7,44 @@ class Ytdl_nfo:
     def __init__(self, file_path, extractor=None):
         self.path = file_path
         self.dir = os.path.dirname(file_path)
-
+        self.data = None
+        self.filename = None
+        self.input_ok = True
+        
         # Read json data
-        with open(self.path, "rt", encoding="utf-8") as f:
-            self.data = json.load(f)
+        if self.input_ok:
+            try:
+                with open(self.path, "rt", encoding="utf-8") as f:
+                    self.data = json.load(f)
+            except json.JSONDecodeError:
+                print(f'Error: Failed to parse JSON in file {self.path}')
+                self.input_ok = False
 
         self.extractor = extractor
-        if extractor is None:
-            self.extractor = self.data['extractor'].lower()
+        if extractor is None and self.data is not None:
+            data_extractor = self.data.get('extractor')
+            if isinstance(data_extractor, str):
+                self.extractor = data_extractor.lower()
 
         if file_path.endswith(".info.json"):
             self.filename = file_path[:-10]
-        else:
-            self.filename = os.path.splitext(self.data['_filename'])[0]
+        elif self.data is not None:
+            data_filename = self.data.get('_filename')
+            if isinstance(data_filename, str):
+                self.filename = os.path.splitext(data_filename)[0]
 
         self.nfo = get_config(self.extractor)
 
     def process(self):
-
+        if not self.input_ok or not self.nfo.config_ok():
+            return False
         self.nfo.generate(self.data)
         self.write_nfo()
         return True
 
     def write_nfo(self):
-        self.nfo.write_nfo(f'{self.filename}.nfo')
+        if self.nfo.generated_ok():
+            self.nfo.write_nfo(f'{self.filename}.nfo')
 
     def print_data(self):
         print(json.dumps(self.data, indent=4, sort_keys=True))

--- a/ytdl_nfo/Ytdl_nfo.py
+++ b/ytdl_nfo/Ytdl_nfo.py
@@ -32,6 +32,8 @@ class Ytdl_nfo:
             data_filename = self.data.get('_filename')
             if isinstance(data_filename, str):
                 self.filename = os.path.splitext(data_filename)[0]
+        if self.filename is None:
+            self.filename = file_path
 
         self.nfo = get_config(self.extractor)
 

--- a/ytdl_nfo/Ytdl_nfo.py
+++ b/ytdl_nfo/Ytdl_nfo.py
@@ -34,22 +34,28 @@ class Ytdl_nfo:
                 self.filename = os.path.splitext(data_filename)[0]
         if self.filename is None:
             self.filename = file_path
-
-        self.nfo = get_config(self.extractor)
-
+        
+        if isinstance(self.extractor, str):
+            self.nfo = get_config(self.extractor)
+        else:
+            self.nfo = None
+    
     def process(self):
-        if not self.input_ok or not self.nfo.config_ok():
+        if not self.input_ok or self.nfo is None or not self.nfo.config_ok():
             return False
         self.nfo.generate(self.data)
         self.write_nfo()
         return True
 
     def write_nfo(self):
-        if self.nfo.generated_ok():
+        if self.nfo is not None and self.nfo.generated_ok():
             self.nfo.write_nfo(f'{self.filename}.nfo')
 
     def print_data(self):
         print(json.dumps(self.data, indent=4, sort_keys=True))
 
     def get_nfo(self):
-        return self.nfo.get_nfo()
+        if self.nfo is not None:
+            return self.nfo.get_nfo()
+        else:
+            return None

--- a/ytdl_nfo/__init__.py
+++ b/ytdl_nfo/__init__.py
@@ -38,7 +38,7 @@ def main():
 
                     if args.overwrite or not os.path.exists(path_no_ext + ".nfo"):
                         print(
-                            f'Processing {args.input} with {extractor_str} extractor')
+                            f'Processing {file_path} with {extractor_str} extractor')
                         file = Ytdl_nfo(file_path, args.extractor)
                         file.process()
 

--- a/ytdl_nfo/nfo.py
+++ b/ytdl_nfo/nfo.py
@@ -8,9 +8,21 @@ from xml.dom import minidom
 
 class Nfo:
     def __init__(self, extractor):
-        with pkg_resources.resource_stream("ytdl_nfo", f"configs/{extractor}.yaml") as f:
-            self.data = yaml.load(f, Loader=yaml.FullLoader)
-
+        self.data = None
+        self.top = None
+        try:
+            extractor_path = f"configs/{extractor}.yaml"
+            with pkg_resources.resource_stream("ytdl_nfo", extractor_path) as f:
+                self.data = yaml.load(f, Loader=yaml.FullLoader)
+        except FileNotFoundError:
+            print(f"No config available for extractor {extractor}")
+    
+    def config_ok(self):
+        return self.data is not None
+    
+    def generated_ok(self):
+        return self.top is not None
+    
     def generate(self, raw_data):
 
         # There should only be one top level node
@@ -101,4 +113,7 @@ class Nfo:
 
 
 def get_config(extractor):
-    return Nfo(extractor.replace(":tab", ""))
+    if isinstance(extractor, str):
+        return Nfo(extractor.replace(":tab", ""))
+    else:
+        return None

--- a/ytdl_nfo/nfo.py
+++ b/ytdl_nfo/nfo.py
@@ -15,7 +15,7 @@ class Nfo:
             with pkg_resources.resource_stream("ytdl_nfo", extractor_path) as f:
                 self.data = yaml.load(f, Loader=yaml.FullLoader)
         except FileNotFoundError:
-            print(f"No config available for extractor {extractor}")
+            print(f"Error: No config available for extractor {extractor}")
     
     def config_ok(self):
         return self.data is not None

--- a/ytdl_nfo/nfo.py
+++ b/ytdl_nfo/nfo.py
@@ -113,7 +113,4 @@ class Nfo:
 
 
 def get_config(extractor):
-    if isinstance(extractor, str):
-        return Nfo(extractor.replace(":tab", ""))
-    else:
-        return None
+    return Nfo(extractor.replace(":tab", ""))


### PR DESCRIPTION
Fixes issues #25 and #26

Also improves behavior when an info.json file is encountered for an extractor that no config yet exists for, and adds a config for vimeo downloads.

---

Invalid JSON (such as in a live_chat.json file) before:

```
Traceback (most recent call last):
  File "C:\Python\python-3.10.2\Scripts\ytdl-nfo-script.py", line 33, in <module>
    sys.exit(load_entry_point('ytdl-nfo', 'console_scripts', 'ytdl-nfo')())
  File "c:\apps\ytdl-nfo\ytdl_nfo\__init__.py", line 42, in main
    file = Ytdl_nfo(file_path, args.extractor)
  File "c:\apps\ytdl-nfo\ytdl_nfo\Ytdl_nfo.py", line 13, in __init__
    self.data = json.load(f)
  File "C:\Python\python-3.10.2\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
  File "C:\Python\python-3.10.2\lib\json\__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "C:\Python\python-3.10.2\lib\json\decoder.py", line 340, in decode
    raise JSONDecodeError("Extra data", s, end)
json.decoder.JSONDecodeError: Extra data: line 2 column 1 (char 596)
(script exits)
```

After:

```
Processing .\Was it Good？ - Pokemon Red ⧸ Blue-g_Aa38-lUtw.live_chat.json with file specific extractor
Error: Failed to parse JSON in file .\Was it Good？ - Pokemon Red ⧸ Blue-g_Aa38-lUtw.live_chat.json
(processing continues)
```

---

Missing extractor config before:

```
Traceback (most recent call last):
  File "C:\Python\python-3.10.2\Scripts\ytdl-nfo-script.py", line 33, in <module>
    sys.exit(load_entry_point('ytdl-nfo', 'console_scripts', 'ytdl-nfo')())
  File "c:\apps\ytdl-nfo\ytdl_nfo\__init__.py", line 42, in main
    file = Ytdl_nfo(file_path, args.extractor)
  File "c:\apps\ytdl-nfo\ytdl_nfo\Ytdl_nfo.py", line 36, in __init__
    self.nfo = get_config(self.extractor)
  File "c:\apps\ytdl-nfo\ytdl_nfo\nfo.py", line 105, in get_config
    return Nfo(extractor.replace(":tab", ""))
  File "c:\apps\ytdl-nfo\ytdl_nfo\nfo.py", line 11, in __init__
    with pkg_resources.resource_stream("ytdl_nfo", f"configs/{extractor}.yaml") as f:
  File "C:\Python\python-3.10.2\lib\site-packages\pkg_resources\__init__.py", line 1136, in resource_stream
    return get_provider(package_or_requirement).get_resource_stream(
  File "C:\Python\python-3.10.2\lib\site-packages\pkg_resources\__init__.py", line 1608, in get_resource_stream
    return open(self._fn(self.module_path, resource_name), 'rb')
FileNotFoundError: [Errno 2] No such file or directory: 'c:\\apps\\ytdl-nfo\\ytdl_nfo\\configs\\vimeo.yaml'
(script exits)
```

After:

```
Processing .\PVC Feces Rig Tour (Home Made) #vanlife-715262741.info.json with file specific extractor
Error: No config available for extractor vimeo
(processing continues)
```
