### PR TITLE
Add vimeo extractor config yaml

### DIFF
--- a/ytdl_nfo/configs/vimeo.yaml
+++ b/ytdl_nfo/configs/vimeo.yaml
@@ -1,0 +1,14 @@
+episodedetails:
+  - title: '{title}'
+  - showtitle: '{uploader}'
+  - uniqueid:
+      attr:
+        type: 'vimeo'
+        default: "true"
+      value: '{id}'
+  - plot: '{description}'
+  - premiered:
+      convert: 'date'
+      input_f: '%Y%m%d'
+      output_f: '%Y-%m-%d'
+      value: '{upload_date}'


### PR DESCRIPTION
And, after adding a vimeo config, an nfo file is written with the expected contents for this video:

https://vimeo.com/715262741

```
<?xml version="1.0" ?>
<episodedetails>
    <title>PVC Feces Rig Tour (Home Made) #vanlife</title>
    <showtitle>Conner O'Malley</showtitle>
    <uniqueid type="vimeo" default="true">715262741</uniqueid>
    <plot>Walgreens Defense Force
Directed by Alan Resnick
Produced by James Trevor
Edited by Harrison Fishman
SFX by Eris Deo
VFX by Cole Kush, Dan Streit and Alan Resnick
Music by Mikal Cronin
Sound Design by Brent Busby
Staring Annie Donley, Robby Ratclif and Alan Resnick</plot>
    <premiered>2022-05-30</premiered>
</episodedetails>
```