### PR TITLE
Fix behavior of -w overwrite flag to always use correct nfo path

### DIFF
--- a/ytdl_nfo/Ytdl_nfo.py
+++ b/ytdl_nfo/Ytdl_nfo.py
@@ -46,10 +46,14 @@ class Ytdl_nfo:
         self.nfo.generate(self.data)
         self.write_nfo()
         return True
-
+    
+    def get_nfo_path(self):
+        return f'{self.filename}.nfo'
+        
     def write_nfo(self):
         if self.nfo is not None and self.nfo.generated_ok():
-            self.nfo.write_nfo(f'{self.filename}.nfo')
+            nfo_path = self.get_nfo_path()
+            self.nfo.write_nfo(nfo_path)
 
     def print_data(self):
         print(json.dumps(self.data, indent=4, sort_keys=True))

--- a/ytdl_nfo/__init__.py
+++ b/ytdl_nfo/__init__.py
@@ -29,6 +29,8 @@ def main():
         for root, dirs, files in os.walk(args.input):
             for file_name in files:
                 file_path = os.path.join(root, file_name)
+                if file_name.endswith(".live_chat.json"):
+                    continue
                 if re.search(args.regex, file_name):
                     file = Ytdl_nfo(file_path, args.extractor)
                     if args.overwrite or not os.path.exists(file.get_nfo_path()):

--- a/ytdl_nfo/__init__.py
+++ b/ytdl_nfo/__init__.py
@@ -30,16 +30,9 @@ def main():
             for file_name in files:
                 file_path = os.path.join(root, file_name)
                 if re.search(args.regex, file_name):
-
-                    path_no_ext = os.path.splitext(file_path)[0]
-                    info_re = r".info$"
-                    if re.search(info_re, file_name):
-                        path_no_ext = re.sub(info_re, '', path_no_ext)
-
-                    if args.overwrite or not os.path.exists(path_no_ext + ".nfo"):
-                        print(
-                            f'Processing {file_path} with {extractor_str} extractor')
-                        file = Ytdl_nfo(file_path, args.extractor)
+                    file = Ytdl_nfo(file_path, args.extractor)
+                    if args.overwrite or not os.path.exists(file.get_nfo_path()):
+                        print(f'Processing {file_path} with {extractor_str} extractor')
                         file.process()
 
 


### PR DESCRIPTION
A hopefully more robust fix than implemented in https://github.com/owdevel/ytdl-nfo/pull/33

This implementation should always check the correct path

Includes a small fix to stop trying to parse `*.live_chat.json` files as this was polluting my log and making it more difficult to test the change locally

Closes #32
Closes #33