### PR TITLE
Add support for nested tags with >

### DIFF
--- a/ytdl_nfo/Ytdl_nfo.py
+++ b/ytdl_nfo/Ytdl_nfo.py
@@ -44,9 +44,10 @@ class Ytdl_nfo:
     def process(self):
         if not self.input_ok or self.nfo is None or not self.nfo.config_ok():
             return False
-        self.nfo.generate(self.data)
-        self.write_nfo()
-        return True
+        generated = self.nfo.generate(self.data)
+        if generated:
+            self.write_nfo()
+        return generated
     
     def get_nfo_path(self):
         return f'{self.filename}.nfo'

--- a/ytdl_nfo/configs/test.yaml
+++ b/ytdl_nfo/configs/test.yaml
@@ -1,0 +1,16 @@
+episodedetails:
+  - genre!: "{categories}"
+  - actor>name!: "{cast}"
+  - really>nested>actor>name>list!: "{cast}"
+  - this>should>be>invalid: "{upload_date}"
+  - normal: "{upload_date}"
+  - converted>date:
+      convert: "date"
+      input_f: "%Y%m%d"
+      output_f: "%Y-%m-%d"
+      value: "{upload_date}"
+  - nested>date!:
+      convert: "date"
+      input_f: "%Y%m%d"
+      output_f: "%Y-%m-%d"
+      value: "{nested_dates}"

--- a/ytdl_nfo/nfo.py
+++ b/ytdl_nfo/nfo.py
@@ -94,7 +94,15 @@ class Nfo:
         child_name = child_name.rstrip('!')
 
         for value in children:
-            child = ET.SubElement(parent, child_name)
+            sub_parent = parent
+            sub_name = child_name
+            sub_index = sub_name.find('>')
+            while sub_index > -1:
+                sub_parent = ET.SubElement(sub_parent, sub_name[:sub_index])
+                sub_name = sub_name[sub_index + 1:]
+                sub_index = sub_name.find('>')
+
+            child = ET.SubElement(sub_parent, sub_name)
             child.text = value
 
             # Add attributes

--- a/ytdl_nfo/nfo.py
+++ b/ytdl_nfo/nfo.py
@@ -31,7 +31,13 @@ class Nfo:
         self.top = ET.Element(top_name)
 
         # Recursively generate the rest of the NFO
-        self.__create_child(self.top, self.data[top_name], raw_data)
+        try:
+            self.__create_child(self.top, self.data[top_name], raw_data)
+        except ValueError as e:
+            print(e)
+            return False
+
+        return True
 
     def __create_child(self, parent, subtree, raw_data):
         # Some .info.json files may not include an upload_date.
@@ -98,6 +104,8 @@ class Nfo:
             sub_name = child_name
             sub_index = sub_name.find('>')
             while sub_index > -1:
+                if not table:
+                    raise ValueError(f'Error with key {sub_name}: > deliminator can only be used for lists')
                 sub_parent = ET.SubElement(sub_parent, sub_name[:sub_index])
                 sub_name = sub_name[sub_index + 1:]
                 sub_index = sub_name.find('>')


### PR DESCRIPTION
Fixes part of #29 

Add support for the '>' modifier in the yaml extractor config. This symbol delimitates tags for nesting purposes.

Example Input:
```json
{
    "categories": [
        "Entertainment",
        "Comedy"
    ],
    "cast": [
        "Penn Jillette",
        "Teller"
    ],
    "upload_date": "20091225",
    "nested_dates": [
        "20091226",
        "20091227",
        "20091228",
        "20091229"
    ]
}
```

Example Extractor:
```yaml
episodedetails:
  - genre!: "{categories}"
  - actor>name!: "{cast}"
  - normal: "{upload_date}"
  - nested>date!:
      convert: "date"
      input_f: "%Y%m%d"
      output_f: "%Y-%m-%d"
      value: "{nested_dates}"
```

Example Output:
```xml
<?xml version="1.0" ?>
<episodedetails>
    <genre>Entertainment</genre>
    <genre>Comedy</genre>
    <actor>
        <name>Penn Jillette</name>
    </actor>
    <actor>
        <name>Teller</name>
    </actor>
    <normal>20091225</normal>
    <nested>
        <date>2009-12-26</date>
    </nested>
    <nested>
        <date>2009-12-27</date>
    </nested>
    <nested>
        <date>2009-12-28</date>
    </nested>
    <nested>
        <date>2009-12-29</date>
    </nested>
</episodedetails>
```