### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Common
+.env
+.vscode
+
+# Git
+.git
+.gitignore
+
+# Docker
+.dockerignore
+docker-compose*.yml
+Dockerfile*
+
+# Nix
+flake.lock
+flake.nix

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.13-slim-bookworm
+
+ENV POETRY_VERSION=2.1.1
+
+RUN pip install --no-cache-dir poetry==${POETRY_VERSION}
+
+WORKDIR /app
+
+COPY . ./
+
+RUN poetry install --without dev
+
+ENTRYPOINT ["poetry", "run", "python", "-m", "ytdl_nfo"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.13-slim-bookworm
 
+# Poetry version
 ENV POETRY_VERSION=2.1.1
 
 RUN pip install --no-cache-dir poetry==${POETRY_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,33 @@
-FROM python:3.13-slim-bookworm
+# https://medium.com/@albertazzir/blazing-fast-python-docker-builds-with-poetry-a78a66f5aed0
+FROM python:3.13-slim-bookworm as build
 
 # Poetry version
 ENV POETRY_VERSION=2.1.1
 
 RUN pip install --no-cache-dir poetry==${POETRY_VERSION}
 
+ENV POETRY_NO_INTERACTION=1 \
+    POETRY_VIRTUALENVS_IN_PROJECT=1 \
+    POETRY_VIRTUALENVS_CREATE=1 \
+    POETRY_CACHE_DIR=/tmp/poetry_cache
+
 WORKDIR /app
 
-COPY . ./
+# Copy only pyproject.toml and poetry.lock first to install dependencies
+COPY pyproject.toml poetry.lock ./
 
-RUN poetry install --without dev
+# Install dependencies and remove Poetry cache afterward
+RUN poetry install --without dev --no-interaction --no-root && rm -rf $POETRY_CACHE_DIR
 
-ENTRYPOINT ["poetry", "run", "python", "-m", "ytdl_nfo"]
+FROM python:3.13-slim-bookworm as run
+
+ENV VIRTUAL_ENV=/app/.venv \
+    PATH="/app/.venv/bin:$PATH"
+
+WORKDIR /app
+
+COPY --from=build ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+
+COPY ytdl_nfo ./ytdl_nfo
+
+ENTRYPOINT ["python", "-m", "ytdl_nfo"]

--- a/README.md
+++ b/README.md
@@ -74,8 +74,11 @@ ytdl-nfo video_folder
 # Create a single NFO file using metadata from `great_video.info.json` and the `custom_extractor_name` template
 ytdl-nfo --extractor custom_extractor_name great_video.info.json
 
-# If using Docker, the ENTRYPOINT is already running `python3 -m ytdl_nfo`, so you just need to pass a volume and your arguments
-docker run -it --rm -v .:/app ytdl-nfo:latest --help
+# If using Docker, the ENTRYPOINT is already running `python3 -m ytdl_nfo`, so you just need to pass your arguments
+docker run -it --rm ytdl-nfo:latest --help
+
+# If using Docker, you need to pass in a volume that contains the JSON file, then specify the path to that JSON file inside the container
+docker run -it --rm --volume ~/Downloads:/my-volume ytdl-nfo:latest --extractor youtube /my-volume/sample.json
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ While this package was originally built for youtube-dl, the goal is to maintain 
 5. Build with `poetry build`
 6. Install from the `dist` directory with `pip install ./dist/ytdl_nfo-x.x.x.tar.gz`
 
+### Docker
+
+1. Build the image `docker build -t ytdl-nfo:latest .`
+
 ## Usage
 
 youtube-dl uses site-specific extractors to collect technical data about a media file. This metadata, along with the extractor ID, are written to a `.info.json` file when the `--write-info-json` flag is used. ytdl-nfo uses a set of YAML configs, located in `ytdl_nfo/configs` to control how metadata from the JSON file is mapped to NFO tags.
@@ -69,6 +73,9 @@ ytdl-nfo video_folder
 
 # Create a single NFO file using metadata from `great_video.info.json` and the `custom_extractor_name` template
 ytdl-nfo --extractor custom_extractor_name great_video.info.json
+
+# If using Docker, the ENTRYPOINT is already running `python3 -m ytdl_nfo`, so you just need to pass a volume and your arguments
+docker run -it --rm -v .:/app ytdl-nfo:latest --help
 ```
 
 ## Contributing


### PR DESCRIPTION
Adds Docker support, image is about 230MB with current setup.

```
> docker image ls
REPOSITORY                             TAG                  IMAGE ID       CREATED          SIZE
ytdl-nfo                               latest               4cbeda16ecae   24 minutes ago   232MB
```

Possible improvements later:

1.  Currently requires the user to build the image first. Would be nice to have pre-built images hosted on DockerHub or GitHub
2. I don't really know poetry, but I'm sure we can make the image smaller by disable caching and also by using a multi-stage build.

```
### Here you can see the JSON file
> ls ~/Downloads/sample.json*
/home/logan/Downloads/sample.json

### Here you can see me running the container
> docker run -it --rm --volume ~/Downloads:/my-volume ytdl-nfo:latest --extractor youtube /my-volume/sample.json
Processing /my-volume/sample.json with youtube extractor

### Here you can see the JSON file, along with the NFO file
> ls ~/Downloads/sample.json*
/home/logan/Downloads/sample.json  /home/logan/Downloads/sample.json.nfo

```

