### PR TITLE
Replace pkg_resources with importlib.resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 description = "Utility to convert youtube-dl/yt-dlp json metadata to .nfo"
 license = { text = "Unlicense" }
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [{ name = "Owen", email = "owdevel@gmail.com" }]
 
 dependencies = ["PyYAML>=6.0.1", "setuptools>=70.2.0"]

--- a/ytdl_nfo/nfo.py
+++ b/ytdl_nfo/nfo.py
@@ -2,7 +2,7 @@ import yaml
 import ast
 import datetime as dt
 import xml.etree.ElementTree as ET
-import pkg_resources
+import importlib.resources
 from collections import defaultdict
 from xml.dom import minidom
 
@@ -13,7 +13,8 @@ class Nfo:
         self.top = None
         try:
             extractor_path = f"configs/{extractor}.yaml"
-            with pkg_resources.resource_stream("ytdl_nfo", extractor_path) as f:
+            ref = importlib.resources.files("ytdl_nfo").joinpath(extractor_path)
+            with ref.open("rb") as f:
                 self.data = yaml.load(f, Loader=yaml.FullLoader)
         except FileNotFoundError:
             print(f"Error: No config available for extractor {extractor} in file {file_path}")


### PR DESCRIPTION
setuptools gives a deprecation warning every time ytdl-nfo runs. i used the migration guide from the backport of importlib.resources ([link](https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-stream)). if the python version bump is a problem it would be pretty straightforward to add the backport as a dependency instead, but i use a recent python3 so i didn't bother.